### PR TITLE
Fix an error if there's no player model equiped

### DIFF
--- a/pointshop2_bodygroups/lua/ps2/modules/bodygroups/cl_dpointshopbodygroupspanel.lua
+++ b/pointshop2_bodygroups/lua/ps2/modules/bodygroups/cl_dpointshopbodygroupspanel.lua
@@ -54,7 +54,7 @@ function PANEL:Init()
 	self:UpdateAndList()
 	
 	hook.Add( "PS2_ItemEquipped", "ItemEquiped", function( ply, item )
-	    if LocalPlayer() != ply or item.id != LocalPlayer().PS2_Slots["Model"].id then return end
+	    	    if LocalPlayer() != ply or !LocalPlayer().PS2_Slots.model or item.id != LocalPlayer().PS2_Slots["Model"].id then return end
 	    timer.Simple( 0, function( )
 	        self.ApplyBtn:SetVisible(false)
 	        self:UpdateAndList()


### PR DESCRIPTION
I.e if you equip a trail while having no playermodel